### PR TITLE
decode tx into hash and query

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "@nylira/vue-field": "^1.0.3",
     "@nylira/vue-form-msg": "1.0.3",
     "axios": "^0.18.0",
+    "base64-js": "^1.3.0",
+    "create-hash": "^1.2.0",
     "no-scroll": "^2.1.0",
+    "varint": "^5.0.0",
     "vue": "2.4.1",
     "vue-router": "2.7.0",
     "vuelidate": "0.5.0"

--- a/src/components/PageBlock.vue
+++ b/src/components/PageBlock.vue
@@ -30,13 +30,16 @@ page(:title="`Block ${block.header.height}`")
     :dd="p.signature.data")
 
   part(title='Transactions')
-    list-item(v-for="tx in block.data.txs" :key="tx.id"
-      dt="Transaction" :dd="TODO")
+  part(v-for="tx in block.data.txs" :title="tx.hash" :key="tx.hash")
+    list-item(v-for="(tx, key) in tx" :key="tx.hash + 'key'" :dt="key" :dd="tx")
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
 import axios from 'axios'
+import createHash from 'create-hash'
+import varint from 'varint'
+import b64 from 'base64-js'
 import ToolBar from './NiToolBar'
 import ListItem from './NiListItem'
 import Part from './NiPart'
@@ -135,6 +138,34 @@ export default {
       let json = await axios.get(url)
       this.block_meta = json.data.result.block_meta
       this.block = json.data.result.block
+      this.block.data.txs && this.queryTxs().catch((err) => console.log(err))
+    },
+    queryTxs () {
+      return this.queryTx(this.block.data.txs.length)
+    },
+    queryTx (len, key = 0) {
+      return new Promise((resolve, reject) => {
+        if (key >= len) resolve()
+        let txstring = atob(this.block.data.txs[key])
+        // console.log(txstring)
+        let txbytes = b64.toByteArray(this.block.data.txs[key])
+        // console.log(txbytes)
+        let varintlen = new Uint8Array(varint.encode(txbytes.length))
+        // console.log(varintlen)
+        let tmp = new Uint8Array(varintlen.byteLength + txbytes.byteLength)
+        tmp.set(new Uint8Array(varintlen), 0)
+        tmp.set(new Uint8Array(txbytes), varintlen.byteLength)
+        // console.log(tmp)
+        let hash = createHash('ripemd160').update(Buffer.from(tmp)).digest('hex')
+        // console.log(hash)
+        let url = `${this.bc.url}/tx?hash=0x${hash}`
+        axios.get(url).then(json => {
+          // console.log(json)
+          json.data.result.string = txstring
+          this.block.data.txs.splice(key, 1, json.data.result)
+          this.queryTx(len, key + 1).then(resolve).catch(reject)
+        }).catch(reject)
+      })
     }
   },
   async mounted () {

--- a/src/store/modules/blockchain.js
+++ b/src/store/modules/blockchain.js
@@ -1,12 +1,17 @@
 import axios from 'axios'
 
 const state = {
-  url: 'http://206.189.22.179:46657',
+  url: 'http://138.68.77.24:46657',
   status: {
     listen_addr: '',
     sync_info: {
       latest_block_height: 0,
       latest_block_hash: ''
+    },
+    node_info: {
+      version: null,
+      network: null,
+      moniker: null
     }
   },
   validators: []

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,10 @@ base64-js@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.3.tgz#fb13668233d9614cf5fb4bce95a9ba4096cdf801"
 
+base64-js@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -1539,7 +1543,7 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
-create-hash@^1.1.0, create-hash@^1.1.2:
+create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   dependencies:
@@ -5614,6 +5618,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+varint@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.0.tgz#d826b89f7490732fabc0c0ed693ed475dcb29ebf"
 
 vary@~1.1.0, vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
issue #5 

adapted python example from @ebuchman in slack to get hash of tx from actual tx, then use with RPC  

added some info to `blockchain.js` initial state to stop errors on loading  

@nylira any idea why i'm getting `router-link` errors from the `list-item` component on pages that contain txs? for ex: http://localhost:8080/block/1250. it's coming from the `list-item`s i added but none of them should trigger the generation of a router-link.

also this format is pretty ugly but didn't know how txs should be shown on the page. any designs to go off of?

![screenshot 2018-05-10 16 17 11](https://user-images.githubusercontent.com/964052/39874296-b0b81ef4-546d-11e8-9386-a279428b067a.png)