### PR TITLE
Dockerfile in multi-stage build. Image only depends on nginx serving static files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:latest as build-env
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -14,5 +14,7 @@ COPY . /usr/src/app
 
 RUN yarn build
 
-EXPOSE 8080
-CMD [ "yarn", "start" ]
+FROM nginx
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build-env /usr/src/app/dist /usr/share/nginx/html


### PR DESCRIPTION
The new docker image only uses nginx (yarn is only used for building), the resulted image is a lot lighter and faster to run.