### PR TITLE
Added `local dev mode' which is a lighter version of Explorer.

### DIFF
--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -1,0 +1,20 @@
+FROM node:latest as build-env
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app/
+COPY yarn.lock /usr/src/app/
+RUN yarn
+
+# Bundle app source
+COPY . /usr/src/app
+
+RUN VUE_APP_LOCAL_DEV=true yarn build
+
+FROM nginx
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build-env /usr/src/app/dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ yarn
 
 # serve with hot reload at localhost:8080
 yarn serve
+
+# serve in "local dev mode" (only enables basic features like the block explorer)
+VUE_APP_LOCAL_DEV=true yarn serve
 ```
 
 ## Deploy

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,23 @@
+server {
+  listen 8080;
+  server_name  localhost;
+
+  root /usr/share/nginx/html;
+
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ @rewrites;
+  }
+
+  location @rewrites {
+    rewrite ^(.+)$ /index.html last;
+  }
+
+  location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+    # Some basic cache-control for static files to be sent to the browser
+    expires max;
+    add_header Pragma public;
+    add_header Cache-Control "public, must-revalidate, proxy-revalidate";
+  }
+}

--- a/src/components/AppMenu.vue
+++ b/src/components/AppMenu.vue
@@ -3,11 +3,11 @@ menu.app-menu
   .app-menu-main
     tm-list-item(to="/" exact @click.native="close" title="Blockchain")
     tm-list-item(to="/nodes" exact @click.native="close" :title="`Full Nodes (${nodes.length})`")
-    tm-list-item(to="/validators" @click.native="close" :title="`Validators (${votingValidators})`" v-bind:class="{ 'active': isValidatorPage }")
-    tm-list-item(to="/validators-revoked" @click.native="close" :title="`Revoked Validators (${revokedValidators})`")
+    tm-list-item(to="/validators" @click.native="close" :title="`Validators (${votingValidators})`" v-bind:class="{ 'active': isValidatorPage }" v-if="!config.localDev")
+    tm-list-item(to="/validators-revoked" @click.native="close" :title="`Revoked Validators (${revokedValidators})`" v-if="!config.localDev")
     tm-list-item(to="/search" exact @click.native="close" title="Search")
 
-  tm-part(title='Testnet Information')
+  tm-part(title='Testnet Information' v-if="!config.localDev")
     tm-list-item(type="anchor" href="https://riot.im/app/#/room/#cosmos_validators:matrix.org" @click.native="close" title="Validator Chat" subtitle="#cosmos-validators" target="_blank")
     tm-list-item(type="anchor" href="https://github.com/cosmos/cosmos-sdk/blob/develop/cmd/gaia/testnets/README.md" @click.native="close" title="Join Testnet" subtitle="run a full node/validator" target="_blank")
     tm-list-item(type="anchor" href="https://gaia.faucetcosmos.network" @click.native="close" title="Steak Faucet" subtitle="vegan artisanal steak" target="_blank")
@@ -26,7 +26,7 @@ export default {
     TmPart
   },
   computed: {
-    ...mapGetters(["proposals", "nodes", "validators"]),
+    ...mapGetters(["proposals", "nodes", "validators", "config"]),
     proposalAlerts() {
       return this.proposals.filter(p => p.flags.read === false).length
     },

--- a/src/components/PageBlock.vue
+++ b/src/components/PageBlock.vue
@@ -131,6 +131,14 @@ export default {
   }),
   methods: {
     async fetchBlock() {
+      if (this.blockchain.localDev) {
+        let url = `${this.blockchain.rpc}/block?height=${this.$route.params.block}`
+        let json = await axios.get(url)
+        this.block_meta = json.data.result.block_meta
+        this.block = json.data.result.block
+        this.block.data.txs && this.queryTxs().catch(err => console.log(err))
+        return
+      }
       let url = `${this.blockchain.lcd}/blocks/${this.$route.params.block}`
       let json = await axios.get(url)
       this.block_meta = json.data.block_meta

--- a/src/components/PageIndex.vue
+++ b/src/components/PageIndex.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 tm-page(title='Testnet Explorer')
-  tm-part(title='Testnet Data')
+  tm-part(title='Testnet Data' v-if="!config.localDev")
     tm-list-item(dt='Testnet Version' :dd='bc.status.node_info.network')
     // tm-list-item(dt='Tendermint Version' :dd='bc.status.node_info.version')
     tm-list-item(dt='Status' :dd='validatorsActive' :href="`${bc.rpc}/consensus_state`" target="_blank")
@@ -25,7 +25,7 @@ tm-page(title='Testnet Explorer')
         tm-field.node-input(
           type="text"
           v-model="bc.rpc")
-    tm-list-item(dt='LCD Endpoint')
+    tm-list-item(dt='LCD Endpoint' v-if="!config.localDev")
       div(slot="dd")
         tm-field.node-input(
           type="text"

--- a/src/store/modules/blockchain.js
+++ b/src/store/modules/blockchain.js
@@ -1,9 +1,15 @@
 import axios from "axios"
 import { RpcClient } from "tendermint"
 
+
+
 const state = {
-  rpc: "https://gaia-seeds.interblock.io",
+  localDev: (process.env.VUE_APP_LOCAL_DEV !== undefined),
+  rpc: (process.env.VUE_APP_LOCAL_DEV !== undefined) ?
+        "http://localhost:26657" : "https://gaia-seeds.interblock.io",
   lcd: "https://gaia-seeds.interblock.io:1317",
+  wss:  (process.env.VUE_APP_LOCAL_DEV !== undefined) ?
+        "ws://localhost:26657" : "wss://gaia-seeds.interblock.io:443",
   status: {
     listen_addr: "",
     sync_info: {
@@ -24,7 +30,7 @@ const state = {
   roundStep: ""
 }
 
-const client = RpcClient("wss://gaia-seeds.interblock.io:443")
+const client = RpcClient(state.wss)
 
 const actions = {
   subNewBlock({ commit, dispatch }) {
@@ -76,6 +82,8 @@ const actions = {
     return Promise.resolve()
   },
   async getValidators({ state, commit, dispatch }) {
+    if (state.localDev)
+        return
     let json = await axios.get(`${state.lcd}/stake/validators`)
     commit("setValidators", json.data)
     dispatch("updateValidatorAvatars")

--- a/src/store/modules/config.js
+++ b/src/store/modules/config.js
@@ -1,7 +1,8 @@
 const state = {
   activeMenu: '',
   blockchainSelect: false,
-  desktop: false
+  desktop: false,
+  localDev: (process.env.VUE_APP_LOCAL_DEV !== undefined)
 }
 
 const mutations = {


### PR DESCRIPTION
Currently, cosmos-explorer exposes some staking functionalities that do not work with a basic Cosmos app (which does not include the staking module for instance).

The local dev mode only includes basic functionalities like the block explorer and what you need for a local cosmos app development.

To enable it:
```shell
VUE_APP_LOCAL_DEV=true yarn serve
```

The Dockerfile.localdev builds a pre-configured local dev enabled docker image.