### PR TITLE
Implemented alternative rpc_port from the query string in local-dev-mode

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -50,7 +50,7 @@ const routes = [
   }
 ]
 
-export default new Router({
+const router = new Router({
   mode: "history",
   routes: routes,
   scrollBehavior(to, from, savedPosition) {
@@ -66,3 +66,18 @@ export default new Router({
     }
   }
 })
+
+router.beforeEach((to, from, next) => {
+    const hasQueryParams = (route) => {
+        return !!Object.keys(route.query).length
+    }
+
+    if (!hasQueryParams(to) && hasQueryParams(from)) {
+        const toWithQuery = Object.assign({}, to, {query: from.query})
+        next(toWithQuery)
+        return
+    }
+    next()
+})
+
+export default router

--- a/src/store/modules/blockchain.js
+++ b/src/store/modules/blockchain.js
@@ -1,15 +1,20 @@
 import axios from "axios"
 import { RpcClient } from "tendermint"
 
-
+const getLocalDevPort = function() {
+    // Support optional local RPC port in the query string
+    const urlParams = new URLSearchParams(window.location.search)
+    const altPort = urlParams.get('rpc_port')
+    return altPort ? altPort : "26657"
+}
 
 const state = {
   localDev: (process.env.VUE_APP_LOCAL_DEV !== undefined),
   rpc: (process.env.VUE_APP_LOCAL_DEV !== undefined) ?
-        "http://localhost:26657" : "https://gaia-seeds.interblock.io",
+        "http://localhost:" + getLocalDevPort() : "https://gaia-seeds.interblock.io",
   lcd: "https://gaia-seeds.interblock.io:1317",
   wss:  (process.env.VUE_APP_LOCAL_DEV !== undefined) ?
-        "ws://localhost:26657" : "wss://gaia-seeds.interblock.io:443",
+        "ws://localhost:" + getLocalDevPort() : "wss://gaia-seeds.interblock.io:443",
   status: {
     listen_addr: "",
     sync_info: {


### PR DESCRIPTION
When using a local explorer for development, the local tendermint app may run on different ports. You may also have multiple tendermint apps running locally for testing.

There is a new query string parameter (rpc_port) that enables using a local explorer with multiple tendermint apps running on any port. The query string port is persistent throughout the navigation.

Example: https://localhost:8080/?rpc_port=42001